### PR TITLE
fake travis vagrant machine

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 .*.swp
 Gemfile.lock
+.vagrant

--- a/Vagrantfile
+++ b/Vagrantfile
@@ -1,0 +1,18 @@
+# -*- mode: ruby -*-
+# vi: set ft=ruby :
+
+Vagrant.configure('2') do |config|
+  config.vm.box = "ubuntu/precise64"
+
+  config.vm.provision "shell", inline: <<-SCRIPT
+    apt-add-repository ppa:brightbox/ruby-ng -y
+    apt-get update -y
+    apt-get -y install ruby2.1 ruby2.1-dev ruby-switch
+    ruby-switch --set ruby2.1
+    gem install bundler --no-rdoc --no-ri
+  SCRIPT
+
+  config.vm.provision "shell",
+    path: 'https://gist.githubusercontent.com/mikz/411dbbc2aad5f147f87b/raw/189d89917ff44dff4e079307b38f8265e05dc07c/travis.rb',
+    args: '/vagrant'
+end


### PR DESCRIPTION
just run `vagrant up` and it will install all dependencies and run tests almost like on travis

could not use [travis-build](https://github.com/travis-ci/travis-build) as it was expecting git repo parameters, and other stuff that we don't have
