### PR TITLE
Add slow request GitHub issue middleware

### DIFF
--- a/middleware/slow-request-github-issue/README.md
+++ b/middleware/slow-request-github-issue/README.md
@@ -1,0 +1,10 @@
+# Slow request GitHub issue middleware
+
+Open a GitHub issue when a request takes too much time. If a slow request to the same URL occurs more than once the middleware updates the associated issue by reopening it.
+
+Default *threshold* is set to 1 second, you can update it in `slow_request_github_issue.lua`.
+
+## Usage
+
+1. Change `GITHUB_ACCESS_TOKEN` in `slow_request_github_issue.lua` with your GitHub API access token.
+1. Change `GITHUB_REPO_FULL_NAME` in `slow_request_github_issue.lua` with your GitHub repository full name, e.g. 'leafo/lapis'.

--- a/middleware/slow-request-github-issue/apitools.json
+++ b/middleware/slow-request-github-issue/apitools.json
@@ -1,0 +1,22 @@
+{
+  "name": "Slow request GitHub issue",
+  "description": "Open a GitHub issue when a request takes too much time",
+  "files": [
+    "slow_request_github_issue.lua"
+  ],
+  "spec": [
+    "slow_request_github_issue_spec.lua"
+  ],
+  "author": "Giovanni Cappellotto",
+  "email": "potomak84@gmail.com",
+  "version": "1.0.0",
+  "categories": [
+    "devops",
+    "notifications",
+    "performances",
+    "github"
+  ],
+  "endpoints": [
+    "*"
+  ]
+}

--- a/middleware/slow-request-github-issue/slow_request_github_issue.lua
+++ b/middleware/slow-request-github-issue/slow_request_github_issue.lua
@@ -1,0 +1,32 @@
+return function(request, next_middleware)
+  local threshold = 1.0 -- 1 second, for less use decimal numbers
+  local github_access_token = 'GITHUB_ACCESS_TOKEN'
+  local github_repo_full_name = 'GITHUB_REPO_FULL_NAME'
+
+  local response = next_middleware()
+
+  if trace.time > threshold then
+    -- request.uri_full is used as key in the middleware bucket
+    local issue_number = bucket.middleware.get(request.uri_full)
+
+    local request_url = 'https://api.github.com/repos/' .. github_repo_full_name .. '/issues'
+    local request_headers = {Authorization = 'token ' .. github_access_token}
+
+    if issue_number == nil then
+      -- create a new GitHub issue
+      local request_body = {title = 'Slow request (' .. trace.time .. ' seconds): ' .. request.uri_full}
+      local issue_response_body = http.simple{method = 'POST', url = request_url, headers = request_headers, body = request_body}
+      local issue = json.decode(issue_response_body)
+
+      -- register issue number
+      bucket.middleware.set(request.uri_full, issue.number)
+    else
+      -- update the GitHub issue (reopen)
+      request_url = request_url .. '/' .. issue_number
+      local request_body = {state = 'open'}
+      http.simple{method = 'PATCH', url = request_url, headers = request_headers, body = request_body}
+    end
+  end
+
+  return response
+end

--- a/middleware/slow-request-github-issue/slow_request_github_issue_spec.lua
+++ b/middleware/slow-request-github-issue/slow_request_github_issue_spec.lua
@@ -1,0 +1,91 @@
+local spec = require 'spec.spec'
+
+describe('Slow request GitHub issue', function()
+  local slow_request_github_issue
+  before_each(function()
+    slow_request_github_issue = spec.middleware('slow-request-github-issue/slow_request_github_issue.lua')
+  end)
+
+  describe('when the response is given quickly', function()
+    it('does nothing', function()
+      local request         = spec.request({method = 'GET', uri = '/'})
+      local next_middleware = spec.next_middleware(function()
+        assert.contains(request, {method = 'GET', uri = '/'})
+        spec.advance_time(0.2) -- less than threshold (1 second)
+        return {status = 200, body = 'ok'}
+      end)
+
+      local response = slow_request_github_issue(request, next_middleware)
+
+      assert.spy(next_middleware).was_called()
+      assert.contains(response, {status = 200, body = 'ok'})
+
+      assert.equal(0, #spec.bucket.middleware:get_keys())
+    end)
+  end)
+
+  describe('when the response takes more than the threshold', function()
+    describe('when it happens once', function()
+      it('creates a GitHub issue and marks the middleware bucket', function()
+        local request         = spec.request({method = 'GET', uri = '/'})
+        local next_middleware = spec.next_middleware(function()
+          assert.contains(request, {method = 'GET', uri = '/'})
+          spec.advance_time(2) -- 2 seconds
+          return {status = 200, body = 'ok'}
+        end)
+
+        spec.mock_http({
+          method   = 'POST',
+          url      = 'https://api.github.com/repos/GITHUB_REPO_FULL_NAME/issues',
+          body     = 'title=Slow+request+%282+seconds%29%3A+http%3A%2F%2Flocalhost%2F',
+          headers  = {Authorization = 'token GITHUB_ACCESS_TOKEN'}
+        }, {
+          body     = '{"url":"https://api.github.com/repos/owner/repo/issues/1","number":1}'
+        })
+
+        local response = slow_request_github_issue(request, next_middleware)
+
+        assert.spy(next_middleware).was_called()
+        assert.contains(response, {status = 200, body = 'ok'})
+
+        assert.truthy(spec.bucket.middleware.get('http://localhost/'))
+      end)
+    end)
+
+    describe('when it happens more than once', function()
+      it('reopens GitHub issue', function()
+        local request         = spec.request({method = 'GET', uri = '/'})
+        local next_middleware = spec.next_middleware(function()
+          assert.contains(request, {method = 'GET', uri = '/'})
+          spec.advance_time(2) -- 2 seconds
+          return {status = 200, body = 'ok'}
+        end)
+
+        spec.mock_http({
+          method   = 'POST',
+          url      = 'https://api.github.com/repos/GITHUB_REPO_FULL_NAME/issues',
+          body     = 'title=Slow+request+%282+seconds%29%3A+http%3A%2F%2Flocalhost%2F',
+          headers  = {Authorization = 'token GITHUB_ACCESS_TOKEN'}
+        }, {
+          body     = '{"url":"https://api.github.com/repos/owner/repo/issues/1","number":1}'
+        })
+
+        spec.mock_http({
+          method   = 'PATCH',
+          url      = 'https://api.github.com/repos/GITHUB_REPO_FULL_NAME/issues/1',
+          body     = 'state=open',
+          headers  = {Authorization = 'token GITHUB_ACCESS_TOKEN'}
+        }, {
+          body     = '{"url":"https://api.github.com/repos/owner/repo/issues/1","number":1}'
+        })
+
+        slow_request_github_issue(request, next_middleware)
+        spec.advance_time(2) -- 2 seconds
+        slow_request_github_issue(request, next_middleware) -- twice
+
+        assert.spy(next_middleware).was_called(2)
+      end)
+    end)
+
+  end)
+end)


### PR DESCRIPTION
Open a GitHub issue when a request takes too much time. If a slow request
to the same URL occurs more than once the middleware updates the associated
issue by reopening it.
